### PR TITLE
[PT-906] Update the OXID order ID field

### DIFF
--- a/Controller/MonduCheckoutController.php
+++ b/Controller/MonduCheckoutController.php
@@ -31,7 +31,7 @@ class MonduCheckoutController extends \OxidEsales\Eshop\Application\Controller\F
         $orderData = $this->_orderMapper->getMappedOrderData($paymentMethod);
 
         $response = $this->_client->createOrder($orderData);
-        $token = isset($response['uuid']) ? $response['uuid'] : 'error';
+        $token = $response['uuid'] ?? 'error';
 
         if ($token !== 'error') {
             $session = Registry::getSession();

--- a/Core/Mappers/MonduAdjustmentMapper.php
+++ b/Core/Mappers/MonduAdjustmentMapper.php
@@ -14,7 +14,7 @@ class MonduAdjustmentMapper
 
         $data = [
             "currency" => $order->getOrderCurrency()->name,
-            "external_reference_id" => $order->getId(),
+            "external_reference_id" => $order->getFieldData('oxorder__oxordernr') ? (string) $order->getFieldData('oxorder__oxordernr') : $order->getId(),
             "amount" => [
                 "net_price_cents" => round($order->getOrderNetSum() * 100),
                 "tax_cents" => round($tax * 100),

--- a/Core/Mappers/MonduInvoiceMapper.php
+++ b/Core/Mappers/MonduInvoiceMapper.php
@@ -11,7 +11,7 @@ class MonduInvoiceMapper
     $invoiceLineItems = $this->getInvoiceLineItems($order);
 
     return MonduHelper::removeEmptyElementsFromArray([
-      'external_reference_id' => $order->getId(),
+      'external_reference_id' => $order->getFieldData('oxorder__oxordernr') ? (string) $order->getFieldData('oxorder__oxordernr') : $order->getId(),
       'invoice_url' => 'http://localhost',
       'gross_amount_cents' => round($order->getFieldData('oxtotalordersum') * 100),
       'line_items' => $invoiceLineItems

--- a/Core/OrderShippingProcessor.php
+++ b/Core/OrderShippingProcessor.php
@@ -52,18 +52,20 @@ class OrderShippingProcessor
         $invoiceDataMapper = oxNew(MonduInvoiceMapper::class);
         $invoiceData = $invoiceDataMapper->getMappedInvoiceData($this->_oOrder);
 
-        $response = $this->client->createInvoice($this->_oMonduOrder->getFieldData('order_uuid'), $invoiceData);
-
-        return $response;
+        return $this->client->createInvoice($this->_oMonduOrder->getFieldData('order_uuid'), $invoiceData);
     }
 
     protected function cancelMonduInvoice()
     {
-        $monduInvoice = array_values($this->_oOrder->getMonduInvoices()->getArray())[0];
+        if ($this->_oOrder->getMonduInvoices()) {
+            $monduInvoice = array_values($this->_oOrder->getMonduInvoices()->getArray())[0];
 
-        if ($monduInvoice) {
-            $response = $this->client->cancelInvoice($this->_oMonduOrder->getFieldData('order_uuid'), $monduInvoice->getFieldData('invoice_uuid'));
-            return $response;
+            if ($monduInvoice) {
+                return $this->client->cancelInvoice(
+                    $this->_oMonduOrder->getFieldData('order_uuid'),
+                    $monduInvoice->getFieldData('invoice_uuid')
+                );
+            }
         }
     }
 

--- a/Core/PaymentHandler/MonduInvoiceHandler.php
+++ b/Core/PaymentHandler/MonduInvoiceHandler.php
@@ -27,7 +27,7 @@ class MonduInvoiceHandler
 
         $updatedOrder = $this->_client->updateOrderExternalInfo(
             $monduOrderUuid,
-            ['external_reference_id' => $oOrder->getId()]
+            ['external_reference_id' => $oOrder->getFieldData('oxorder__oxordernr') ? (string) $oOrder->getFieldData('oxorder__oxordernr') : $oOrder->getId()]
         );
 
         $monduOrder = $this->_client->getMonduOrder($updatedOrder['uuid']);
@@ -36,6 +36,7 @@ class MonduInvoiceHandler
             return false;
         }
 
+        $session->setVariable('mondu_created_order_uuid', $monduOrderUuid);
         $this->storeMonduOrder($oOrder, $monduOrder);
         $this->clearSession();
 

--- a/Core/PaymentHandler/MonduInvoiceHandler.php
+++ b/Core/PaymentHandler/MonduInvoiceHandler.php
@@ -25,14 +25,9 @@ class MonduInvoiceHandler
             return false;
         }
 
-        $updatedOrder = $this->_client->updateOrderExternalInfo(
-            $monduOrderUuid,
-            ['external_reference_id' => $oOrder->getFieldData('oxorder__oxordernr') ? (string) $oOrder->getFieldData('oxorder__oxordernr') : $oOrder->getId()]
-        );
+        $monduOrder = $this->_client->getMonduOrder($monduOrderUuid);
 
-        $monduOrder = $this->_client->getMonduOrder($updatedOrder['uuid']);
-
-        if (!$updatedOrder || !$monduOrder) {
+        if (!$monduOrder) {
             return false;
         }
 

--- a/Core/PaymentHandler/MonduInvoiceHandler.php
+++ b/Core/PaymentHandler/MonduInvoiceHandler.php
@@ -36,7 +36,6 @@ class MonduInvoiceHandler
             return false;
         }
 
-        $session->setVariable('mondu_created_order_uuid', $monduOrderUuid);
         $this->storeMonduOrder($oOrder, $monduOrder);
         $this->clearSession();
 

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -40,11 +40,16 @@ class Order extends Order_parent
     public function getMonduInvoices()
     {
         if ($this->isMonduPayment()) {
-            $sQuery = 'SELECT * FROM `oemondu_invoices` WHERE `invoice_id`=:oxorderid ORDER BY created_at DESC';
+            $sQuery = 'SELECT * FROM `oemondu_invoices` WHERE `invoice_id` IN (:oxorderid, :oxordernr) ORDER BY created_at DESC';
 
             $oMonduInvoices = oxNew(ListModel::class);
             $oMonduInvoices->init(MonduInvoice::class);
-            $oMonduInvoices->selectString($sQuery, [':oxorderid' => $this->getFieldData('oxorder__oxordernr')]);
+            $oMonduInvoices->selectString(
+                $sQuery, [
+                    ':oxorderid' => $this->getId(),
+                    ':oxordernr' => $this->getFieldData('oxorder__oxordernr')
+                ]
+            );
 
             return $oMonduInvoices;
         }

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -91,26 +91,17 @@ class Order extends Order_parent
     public function finalizeOrder(\OxidEsales\Eshop\Application\Model\Basket $oBasket, $oUser, $blRecalculatingOrder = false)
     {
         $result = parent::finalizeOrder($oBasket, $oUser, $blRecalculatingOrder);
-        $session = Registry::getSession();
-        $monduOrderUuid = $session->getVariable('mondu_created_order_uuid');
+        $monduOrderUuid = array_values($this->getMonduOrders()->getArray())[0]->getFieldData('order_uuid');
 
-        if (!$monduOrderUuid) {
+        if (!$monduOrderUuid || !$this->getFieldData('oxorder__oxordernr')) {
             return $result;
         }
 
         $this->client->updateOrderExternalInfo(
             $monduOrderUuid,
-            ['external_reference_id' => $this->getFieldData('oxorder__oxordernr') ? (string) $this->getFieldData('oxorder__oxordernr') : $this->getId()]
+            ['external_reference_id' => (string) $this->getFieldData('oxorder__oxordernr')]
         );
 
-        $this->clearSession();
-
         return $result;
-    }
-
-    protected function clearSession()
-    {
-        $session = Registry::getSession();
-        $session->deleteVariable('mondu_created_order_uuid');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mondu/bnpl-checkout-oxid",
     "description": "Mondu payment method for the OXID eShop.",
     "type": "oxideshop-module",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/metadata.php
+++ b/metadata.php
@@ -10,7 +10,7 @@ $aModule = array(
         'en' => 'Module for Mondu payment.',
     ),
     'thumbnail'    => 'out/src/images/logo.png',
-    'version'      => '1.0.0',
+    'version'      => '1.0.1',
     'author'       => 'Mondu GmbH',
     'url'          => 'https://www.mondu.ai',
     'email'        => 'contact@mondu.ai',


### PR DESCRIPTION
## Description

This PR aims to change the order process flow and use the ORDERNR as the external_reference_id on the Mondu side.

Release: p
Tickets: [PT-906](https://mondu.atlassian.net/browse/PT-906)

Fixes # (issue)
https://mondu.atlassian.net/browse/PT-906

- [X] This change requires a documentation update

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings


[PT-906]: https://mondu.atlassian.net/browse/PT-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ